### PR TITLE
Make formula download the latest version (0.2.1)

### DIFF
--- a/growly.rb
+++ b/growly.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Growly < Formula
   homepage 'https://github.com/ryankee/growly'
   head 'https://github.com/ryankee/growly.git'
-  url 'https://github.com/downloads/ryankee/growly/growly-v0.2.0.tar.gz'
+  url 'https://github.com/ryankee/growly/archive/v0.2.1.zip'
   md5 'a3e4922d619cfeb00009dc55163f0974'
 
   def install


### PR DESCRIPTION
Switch to using github release tags for the archive download:
  `git tag v0.2.1`

Fixes #5
